### PR TITLE
Delegate to the fan-gopher CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore release artifacts
+dist/

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,12 +1,12 @@
 import re
 import datetime
 import json
+import subprocess
+from os.path import abspath
+import platform
 
 media_name_regex = r"(Only[F|f]ans[ ]?)\-? ([a-zA-Z0-9]+)( \-)? ([0-9]{4})[ ]?\-?([0-9]{2})[ ]?\-?([0-9]{2})[ ]?\-? ([0-9]+)[ ]?\-? (.+)"
 result_id_regex = r"onlyfans::actor::(.+)::scene_id::([0-9]+)::post_year::([0-9]+)::post_month::([0-9]+)::post_day::([0-9]+)"
-
-actor_portrait_urls = json.loads(Prefs["actor_portrait_urls"])
-default_actor_portrait_url = Prefs["default_actor_portrait_url"]
 
 def Start():
   pass
@@ -21,6 +21,30 @@ def FixTitle(title):
   fixed_title = re.sub(" Pov$", " POV", fixed_title)
   fixed_title = re.sub(" Pov ", " POV ", fixed_title)
   return fixed_title
+
+def ExecFanGopher(args):
+    platform_system = platform.system()
+    fan_gopher_executable = ""
+    if platform_system == "Windows":
+      fan_gopher_executable = "winx64-1.0.exe"
+    elif platform_system == "Darwin":
+      fan_gopher_executable = "macx64-1.0"
+    else:
+      # Assume Linux for all other scenarios
+      fan_gopher_executable = "linuxx64-1.0"
+
+    # Working directory is presumed to be:
+    # Plex Media Server\Plug-in Support\Data\com.plexapp.agents.fansforyou
+    # However, we want to be executing from:
+    # Plex Media Server\Plug-ins\FansForYou.Bundle\Contents\Code
+    fan_gopher_path = abspath('../../../Plug-ins/FansForYou.Bundle/Contents/Code/fan-gopher-' + fan_gopher_executable)
+    final_args = [fan_gopher_path]
+    final_args.extend(args)
+    app_output = "" + subprocess.check_output(final_args)
+    for outputLine in app_output.split('\n'):
+      if outputLine.startswith('{') and outputLine.endswith('}'):
+        return outputLine
+    return ""
 
 
 class FansForYouAgent(Agent.Movies):
@@ -42,6 +66,13 @@ class FansForYouAgent(Agent.Movies):
     scene_id = regex_match.group(7)
     scene_title = FixTitle(regex_match.group(8))
 
+    outputJson = ExecFanGopher(["-postID=" + scene_id, "-creatorName=" + artist, "-verify=true"])
+    parsedResults = json.loads(outputJson)
+    if "error" in parsedResults:
+      if "true" == parsedResults["error"]:
+        Log("Unable to verify post for creator " + artist + " can be found for ID " + scene_id + ": " + parsedResults["errorMessage"])
+        return
+
     results.Append(MetadataSearchResult(id="onlyfans::actor::" + artist + "::scene_id::" + scene_id + "::post_year::" + year + "::post_month::" + month + "::post_day::" + day, name=scene_title, year=int(year), lang='en', score=100))
 
   def update(self, metadata, media, lang):
@@ -56,18 +87,24 @@ class FansForYouAgent(Agent.Movies):
     month = int(regex_match.group(4))
     day = int(regex_match.group(5))
 
+    detailOutput = ExecFanGopher(["-postID=" + scene_id, "-creatorName=" + artist, "-get-details=true"])
+    parsedDetails = json.loads(detailOutput)
+    if "error" in parsedDetails:
+      if "true" == parsedDetails["error"]:
+        Log("Unable to get details for post for creator " + artist + " can be found for ID " + scene_id + ": " + parsedDetails["errorMessage"])
+        return
+
     # Actors
     metadata.roles.clear()
-    role = metadata.roles.new()
-    role.name = artist
-    if artist in actor_portrait_urls.keys():
-      role.photo = actor_portrait_urls[artist]
-    else:
-      role.photo = default_actor_portrait_url
+    for actorDetail in parsedDetails["actorDetails"]:
+      role = metadata.roles.new()
+      role.name = actorDetail["actorName"]
+      role.photo = actorDetail["profileImageUrl"]
 
     metadata.content_rating = "XXX"
     metadata.originally_available_at = datetime.datetime(int(year), int(month), int(day))
     metadata.year = metadata.originally_available_at.year
+    metadata.summary = parsedDetails["videoDetails"]["videoDescription"]
     
     metadata.collections.clear()
     metadata.collections.add(artist)

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,14 +1,2 @@
 [
-  {
-    "id":"actor_portrait_urls",
-    "label":"A JSON object keying OnlyFans actor names to the URLs of the portrait to be used for them",
-    "type":"text",
-    "default":"{}"
-  },
-  {
-    "id":"default_actor_portrait_url",
-    "label":"The URL to be used for the actor portrait in lieu of a defined portrait",
-    "type":"text",
-    "default":"https://pbs.twimg.com/profile_images/1473290471648731146/EWPMeJq__400x400.jpg"
-  },
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+release:
+	rm -rf dist
+	mkdir dist
+	mkdir dist/staging
+	cp -r Contents dist/staging/Contents
+	cp LICENSE dist/staging/LICENSE
+	cp README.md dist/staging/README.md
+	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0/fan-gopher-linuxx64-1.0 --output dist/staging/Contents/Code/fan-gopher-linuxx64-1.0
+	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0/fan-gopher-macx64-1.0 --output dist/staging/Contents/Code/fan-gopher-macx64-1.0
+	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0/fan-gopher-winx64-1.0.exe --output dist/staging/Contents/Code/fan-gopher-winx64-1.0.exe
+	chmod -R 755 dist/staging
+	(cd dist/staging && zip -r - .) > dist/FansForYou.bundle.zip

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ As an example:
 OnlyFans - Petittits - 2022-02-10 - 268440502 - Dirty Talk and POV.mp4
 ```
 
-## Actor Portrait URLs
+## Installation
 
-Since this agent does not communicate with OnlyFans itself, this metadata agent exposes a way to provide a JSON object that keys OnlyFans account IDs to a portrait URL you have provided for that actor.
+Download the FansForYou.Bundle.zip of your preferred release and place the contents of that ZIP file within a `Plug-ins\FansForYou.bundle` directory (such that, for example, the `Contents` folder is directly beneath that folder) within your Plex Media Service user data (e.g., within `%LOCALAPPDATA%\Plex Media Server\` on Windows).
 
-Using the example above, if you want a specific portrait URL to be used for the Petittits actor portrait, you can specify that in the actor portrait URLs like so:
+## Troubleshooting
 
-```
-{"Petittits":"https://i.ytimg.com/vi/iik25wqIuFo/maxresdefault.jpg"}
-```
+If you need help troubleshooting issues with this agent, refer to here.
 
-This _is_ case-sensitive, so make sure your OnlyFans account IDs are consistent!
+### Logs
+
+The CLI utility used by this agent - `fan-gopher` - writes logs to the `fan-gopher.log` file located in `Plug-in Support\Data\com.plexapp.agents.fansforyou` within your Plex Media Server user data (e.g., within `%LOCALAPPDATA%\Plex Media Server\` on Windows).


### PR DESCRIPTION
Use the new [fan-gopher](https://github.com/fansforyou/fan-gopher) CLI tool to scrape OnlyFans' website for data. This allows the pulling of data rendered by JavaScript, which had little to no support in native Python tooling.