### PR TITLE
Bump up to gopher 1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore release artifacts
 dist/
+
+# Ignore IDE artifacts
+.vscode

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -26,12 +26,12 @@ def ExecFanGopher(args):
     platform_system = platform.system()
     fan_gopher_executable = ""
     if platform_system == "Windows":
-      fan_gopher_executable = "winx64-1.0.exe"
+      fan_gopher_executable = "winx64-1.0.1.exe"
     elif platform_system == "Darwin":
-      fan_gopher_executable = "macx64-1.0"
+      fan_gopher_executable = "macx64-1.0.1"
     else:
       # Assume Linux for all other scenarios
-      fan_gopher_executable = "linuxx64-1.0"
+      fan_gopher_executable = "linuxx64-1.0.1"
 
     # Working directory is presumed to be:
     # Plex Media Server\Plug-in Support\Data\com.plexapp.agents.fansforyou

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ release:
 	cp -r Contents dist/staging/Contents
 	cp LICENSE dist/staging/LICENSE
 	cp README.md dist/staging/README.md
-	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0/fan-gopher-linuxx64-1.0 --output dist/staging/Contents/Code/fan-gopher-linuxx64-1.0
-	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0/fan-gopher-macx64-1.0 --output dist/staging/Contents/Code/fan-gopher-macx64-1.0
-	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0/fan-gopher-winx64-1.0.exe --output dist/staging/Contents/Code/fan-gopher-winx64-1.0.exe
+	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0.1/fan-gopher-linuxx64-1.0.1 --output dist/staging/Contents/Code/fan-gopher-linuxx64-1.0.1
+	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0.1/fan-gopher-macx64-1.0.1 --output dist/staging/Contents/Code/fan-gopher-macx64-1.0.1
+	curl -L0 https://github.com/fansforyou/fan-gopher/releases/download/v1.0.1/fan-gopher-winx64-1.0.1.exe --output dist/staging/Contents/Code/fan-gopher-winx64-1.0.1.exe
 	chmod -R 755 dist/staging
 	(cd dist/staging && zip -r - .) > dist/FansForYou.bundle.zip


### PR DESCRIPTION
gopher 1.0.1 has a bug that's necessary, so bump up the usage and release that.